### PR TITLE
nmsg_msgtype.pyx: added types member with list of all available message types

### DIFF
--- a/nmsg_msgtype.pyx
+++ b/nmsg_msgtype.pyx
@@ -3,12 +3,15 @@ class _msgtype(object):
         cdef char *vname_str
         cdef char *mname_str
 
+        self.types = dict()
+
         for vid from 1 <= vid <= nmsg_msgmod_get_max_vid():
             vname_str = nmsg_msgmod_vid_to_vname(vid)
 
             if vname_str:
                 vname = str(vname_str).lower()
                 v_dict = {}
+                self.types[vname] = list()
 
                 for msgtype from 1 <= msgtype <= nmsg_msgmod_get_max_msgtype(vid):
                     mname_str = nmsg_msgmod_msgtype_to_mname(vid, msgtype)
@@ -21,6 +24,7 @@ class _msgtype(object):
                             '__msgtype': msgtype,
                         }
                         v_dict[mname] = type('%s_%s' % (vname, mname), (_meta_message,), m_dict)
+                    self.types[vname].append(mname)
                 v_dict['_vname'] = vname
                 v_dict['_vid'] = vid
 


### PR DESCRIPTION
This is not functionally necessary but it will make nmsg easier to use.  I've added a dictionary of vendors and msg types.  A user can  see which message types are available with code like this:

```
import nmsg
for vname,mnames in nmsg.msgtype.types.items():
    for mname in mnames:
        print '%s.%s' % (vname, mname)
```
