### PR TITLE
Enable method signatures in docs

### DIFF
--- a/_nmsg.pyx
+++ b/_nmsg.pyx
@@ -1,3 +1,5 @@
+#cython: embedsignature=True
+
 # Copyright (c) 2009-2014 by Farsight Security, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/_nmsg.pyx
+++ b/_nmsg.pyx
@@ -1,3 +1,17 @@
+# Copyright (c) 2009-2014 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import socket
 import time

--- a/examples/nmsg_cat.py
+++ b/examples/nmsg_cat.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2009-2014 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import nmsg
 import sys
 

--- a/examples/nmsg_channel_dump.py
+++ b/examples/nmsg_channel_dump.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2009-2014 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import nmsg
 import socket
 import sys

--- a/examples/nmsg_encode_hello_client.py
+++ b/examples/nmsg_encode_hello_client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2009-2014 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import sys
 import time
 

--- a/examples/nmsg_encode_hello_server.py
+++ b/examples/nmsg_encode_hello_server.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2009-2014 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import sys
 
 import nmsg

--- a/examples/nmsg_file_dump.py
+++ b/examples/nmsg_file_dump.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2009-2014 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import nmsg
 import sys
 import time

--- a/examples/nmsg_io_callback.py
+++ b/examples/nmsg_io_callback.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2009-2014 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import nmsg
 import sys
 

--- a/examples/nmsg_message.py
+++ b/examples/nmsg_message.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2009-2014 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import nmsg
 
 o = nmsg.output.open_sock('127.0.0.1', 9430)

--- a/examples/nmsg_nonblocking.py
+++ b/examples/nmsg_nonblocking.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2009-2014 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import select
 import sys
 

--- a/examples/nmsg_sock_dump.py
+++ b/examples/nmsg_sock_dump.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2009-2014 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import nmsg
 import socket
 import sys

--- a/nmsg.pxi
+++ b/nmsg.pxi
@@ -1,3 +1,17 @@
+# Copyright (c) 2009-2014 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cdef extern from "stdio.h":
     ctypedef void FILE
     FILE *stdout

--- a/nmsg.py
+++ b/nmsg.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2009-2014 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import ctypes
 import sys
 

--- a/nmsg_input.pyx
+++ b/nmsg_input.pyx
@@ -1,3 +1,5 @@
+#cython: embedsignature=True
+
 # Copyright (c) 2009-2014 by Farsight Security, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nmsg_input.pyx
+++ b/nmsg_input.pyx
@@ -1,3 +1,17 @@
+# Copyright (c) 2009-2014 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 def input_open_file(obj):
     if type(obj) == str:
         obj = open(obj)

--- a/nmsg_io.pyx
+++ b/nmsg_io.pyx
@@ -1,3 +1,5 @@
+#cython: embedsignature=True
+
 # Copyright (c) 2009-2014 by Farsight Security, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nmsg_io.pyx
+++ b/nmsg_io.pyx
@@ -1,3 +1,17 @@
+# Copyright (c) 2009-2014 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cdef class io(object):
     cdef nmsg_io_t _instance
 

--- a/nmsg_message.pyx
+++ b/nmsg_message.pyx
@@ -1,3 +1,5 @@
+#cython: embedsignature=True
+
 # Copyright (c) 2009-2014 by Farsight Security, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nmsg_message.pyx
+++ b/nmsg_message.pyx
@@ -1,3 +1,17 @@
+# Copyright (c) 2009-2014 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cdef class message(object):
     cdef msgmod _mod
     cdef nmsg_message_t _instance

--- a/nmsg_msgmod.pyx
+++ b/nmsg_msgmod.pyx
@@ -1,3 +1,5 @@
+#cython: embedsignature=True
+
 # Copyright (c) 2009-2014 by Farsight Security, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nmsg_msgmod.pyx
+++ b/nmsg_msgmod.pyx
@@ -1,3 +1,17 @@
+# Copyright (c) 2009-2014 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 def msgmod_get_max_msgtype(unsigned vid):
     cdef char *vname
     vname = nmsg_msgmod_vid_to_vname(vid)

--- a/nmsg_msgtype.pyx
+++ b/nmsg_msgtype.pyx
@@ -1,3 +1,5 @@
+#cython: embedsignature=True
+
 # Copyright (c) 2009-2014 by Farsight Security, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nmsg_msgtype.pyx
+++ b/nmsg_msgtype.pyx
@@ -1,3 +1,17 @@
+# Copyright (c) 2009-2014 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 class _msgtype(object):
     def __init__(self):
         cdef char *vname_str

--- a/nmsg_output.pyx
+++ b/nmsg_output.pyx
@@ -1,3 +1,17 @@
+# Copyright (c) 2009-2014 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 def output_open_file(obj, size_t bufsz=NMSG_WBUFSZ_MAX):
     if type(obj) == str:
         obj = open(obj, 'w')

--- a/nmsg_output.pyx
+++ b/nmsg_output.pyx
@@ -1,3 +1,5 @@
+#cython: embedsignature=True
+
 # Copyright (c) 2009-2014 by Farsight Security, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nmsg_util.pyx
+++ b/nmsg_util.pyx
@@ -1,3 +1,5 @@
+#cython: embedsignature=True
+
 # Copyright (c) 2009-2014 by Farsight Security, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nmsg_util.pyx
+++ b/nmsg_util.pyx
@@ -1,3 +1,17 @@
+# Copyright (c) 2009-2014 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 def ip_pton(ip):
     try:
         return socket.inet_pton(socket.AF_INET, ip)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2009-2014 by Farsight Security, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 NAME = 'pynmsg'
 VERSION = '0.3.1'
 


### PR DESCRIPTION
Cython has a compiler directive that adds method signatures to the generated pydocs.  I don't know why it's disabled by default.  This pull request turns that on throughout pynmsg.  I've also added the copyright boilerplate for good measure.