### PR TITLE
Prep 0.5.0-2 release for libnmsg depends.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pynmsg (0.5.0-2) debian-farsightsec; urgency=medium
+
+  * Specify libnmsg-dev 1.0.0, 0mq migration (libzmq).
+
+ -- Farsight Security, Inc. <software@farsightsecurity.com>  Thu, 23 Sep 2021 17:31:03 +0000
+
 pynmsg (0.5.0-1) debian-farsightsec; urgency=medium
 
   * Add Python3 support.

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Build-Depends:
  python3-setuptools,
  cython (>= 0.15~),
  cython3,
- libnmsg-dev (>= 0.10.0~),
+ libnmsg-dev (>= 1.0.0~),
  pkg-config,
 Standards-Version: 3.9.8
 


### PR DESCRIPTION
Rebuild and specify our libnmsg-dev version to the new 0mq version (1.0.0).