### PR TITLE
Remove PyEval_InitThreads()

### DIFF
--- a/_nmsg.pyx
+++ b/_nmsg.pyx
@@ -23,8 +23,6 @@ import threading
 
 include "nmsg.pxi"
 
-PyEval_InitThreads()
-
 chalias_fnames = (
     '/etc/nmsgtool.chalias',
     '/etc/nmsg.chalias',

--- a/nmsg.pxi
+++ b/nmsg.pxi
@@ -45,7 +45,6 @@ cdef extern from "time.h":
 cdef extern from "Python.h":
     void Py_INCREF(object)
     void Py_DECREF(object)
-    void PyEval_InitThreads()
     int PyErr_CheckSignals()
     int PyErr_ExceptionMatches(object)
 


### PR DESCRIPTION
Starting Python 3.7 it is now called by automatically:
https://docs.python.org/3.9/c-api/init.html#c.PyEval_InitThreads